### PR TITLE
Fix example stream URL & add Colab button to scene indexing notebook

### DIFF
--- a/quickstart/scene_level_metadata_indexing.ipynb
+++ b/quickstart/scene_level_metadata_indexing.ipynb
@@ -1,23 +1,15 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "KZ634ujnvhAr"
+      },
       "source": [
         "# 📌 VideoDB F1 Race Search Pipeline (Turn Detection & Metadata Filtering)\n",
+        "\n",
+        "<a href=\"https://colab.research.google.com/github/video-db/videodb-cookbook/blob/main/quickstart/scene_level_metadata_indexing.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "\n",
         "## 🎯 Objective\n",
         "This notebook demonstrates **scene-level metadata filtering** in an F1 race video to enable precise search and retrieval.\n",
         "\n",
@@ -27,26 +19,21 @@
         "✔ **Describing scenes** using AI-generated metadata  \n",
         "✔ **Indexing scenes** with structured metadata (`camera_view` & `action_type`)  \n",
         "✔ **Searching scenes** using **semantic search + metadata filtering**  \n"
-      ],
-      "metadata": {
-        "id": "KZ634ujnvhAr"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "XMhmSsaEv3wK"
+      },
       "source": [
         "# 📦 Install VideoDB SDK  \n",
         "Required for connecting and processing video data.  \n"
-      ],
-      "metadata": {
-        "id": "XMhmSsaEv3wK"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install videodb"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -55,11 +42,10 @@
         "id": "SX2wQvG8v3es",
         "outputId": "2f19fa41-eea7-4584-f034-0bf07a3f0137"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Collecting videodb\n",
             "  Downloading videodb-0.2.10.tar.gz (25 kB)\n",
@@ -82,43 +68,63 @@
             "Successfully installed backoff-2.2.1 videodb-0.2.10\n"
           ]
         }
+      ],
+      "source": [
+        "!pip install videodb"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "qRrD_QWrwC7C"
+      },
       "source": [
         "# 🔑 Set Up API Key  \n",
         "Authenticate with VideoDB to access indexing and search functionalities.  \n"
-      ],
-      "metadata": {
-        "id": "qRrD_QWrwC7C"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PLZ3zTVVv7nM"
+      },
+      "outputs": [],
       "source": [
         "import os\n",
         "\n",
         "os.environ[\"VIDEO_DB_API_KEY\"] = \"\""
-      ],
-      "metadata": {
-        "id": "PLZ3zTVVv7nM"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "8r002aIkwTpc"
+      },
       "source": [
         "# 🌐 Connect to VideoDB  \n",
         "Establishes connection to manage video storage, indexing, and search.  \n"
-      ],
-      "metadata": {
-        "id": "8r002aIkwTpc"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "b3OqQrzxwQuY",
+        "outputId": "c14a24d9-0b47-44f7-aa7e-18fdda67bc94"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "c-81fc6459-fe30-44ac-8c5b-ea0898c2e152\n"
+          ]
+        }
+      ],
       "source": [
         "from videodb import connect\n",
         "\n",
@@ -126,61 +132,47 @@
         "coll = conn.get_collection()\n",
         "\n",
         "print(coll.id)"
-      ],
-      "metadata": {
-        "id": "b3OqQrzxwQuY",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "c14a24d9-0b47-44f7-aa7e-18fdda67bc94"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "c-81fc6459-fe30-44ac-8c5b-ea0898c2e152\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "kJ8mFZtowpaz"
+      },
       "source": [
         "# 🎥 Upload F1 Race Video  \n",
         "Adds the video to VideoDB for further processing.  \n"
-      ],
-      "metadata": {
-        "id": "kJ8mFZtowpaz"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "video = coll.upload(url=\"https://www.youtube.com/watch?v=2-oslsgSaTI\")\n",
-        "print(video.id)"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "jGRKA8wZwZcp",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "jGRKA8wZwZcp",
         "outputId": "fbaf7c62-e372-44a3-b2e2-ea42c6fb80f4"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "m-z-01954d91-651d-7ef0-a022-18aad60eabdb\n"
           ]
         }
+      ],
+      "source": [
+        "video = coll.upload(url=\"https://www.youtube.com/watch?v=2-oslsgSaTI\")\n",
+        "print(video.id)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "twKYyQFb2VVl"
+      },
       "source": [
         "## ✂️ Extracting Scenes (Every 2 Seconds)\n",
         "We split the video into **2-second scenes**, extracting a **single frame per scene** for indexing.\n",
@@ -188,13 +180,28 @@
         "### **Why?**\n",
         "- This ensures **granular indexing**, making **scene-level filtering more precise**.\n",
         "- By extracting **key frames**, we can later **assign AI-generated metadata** to describe each scene accurately.\n"
-      ],
-      "metadata": {
-        "id": "twKYyQFb2VVl"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XWE6xx0v2h3s",
+        "outputId": "b87a73b5-5f75-43d8-d872-4f62a2f4c408"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Scene Collection ID: tt2smf1\n",
+            "Total Scenes Extracted: 148\n"
+          ]
+        }
+      ],
       "source": [
         "# Extract Scenes Every 2 Seconds (1 Frame per Scene)\n",
         "from videodb import SceneExtractionType\n",
@@ -209,28 +216,13 @@
         "scenes = scene_collection.scenes\n",
         "\n",
         "print(f\"Total Scenes Extracted: {len(scenes)}\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "XWE6xx0v2h3s",
-        "outputId": "b87a73b5-5f75-43d8-d872-4f62a2f4c408"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Scene Collection ID: tt2smf1\n",
-            "Total Scenes Extracted: 148\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "FuftaJDm3-By"
+      },
       "source": [
         "## 🔍 Generating Scene Metadata\n",
         "To **make scenes searchable**, we use AI to **describe & categorize** each scene with the following **structured metadata**:\n",
@@ -247,53 +239,11 @@
         "### **🚀 Why This Matters**\n",
         "- **Metadata filtering** allows us to **search for specific race scenarios.**  \n",
         "- **Combining metadata & semantic search** makes retrieval **highly precise**.  \n"
-      ],
-      "metadata": {
-        "id": "FuftaJDm3-By"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "from videodb.scene import Scene\n",
-        "\n",
-        "# List to store described scenes\n",
-        "described_scenes = []\n",
-        "\n",
-        "for scene in scenes:\n",
-        "    print(f\"Scene from {scene.start}s to {scene.end}s\")\n",
-        "\n",
-        "    # Generate metadata\n",
-        "    camera_view = scene.describe(\n",
-        "        'Select ONLY one of these camera views (DO NOT describe it, JUST return the category name): [\"road_ahead\", \"helmet_selfie\"]. If the view does not match exactly, pick the closest one.'\n",
-        "    )\n",
-        "\n",
-        "    action_type = scene.describe(\n",
-        "        'Select ONLY one of these options based on the action being performed by the driver (DO NOT describe it, JUST return the category name): [\"clear_road\", \"chasing\"]. If the view does not match exactly, pick the closest one.'\n",
-        "    )\n",
-        "\n",
-        "    scene_description = scene.describe(\n",
-        "        \"Clearly describe a Formula 1 scene by specifying the scene type, the drivers and teams involved, the specific location on the track, and the key action or significance of the moment. Use concise, yet rich language, targeting Formula 1 enthusiasts seeking precise scene descriptions.\"\n",
-        "    )\n",
-        "\n",
-        "    print(f\"Camera View: {camera_view} | Action Type: {action_type}\")\n",
-        "    print(f\"Scene Description: {scene_description}\")\n",
-        "\n",
-        "    # Create Scene object with metadata\n",
-        "    described_scene = Scene(\n",
-        "        video_id=video.id,\n",
-        "        start=scene.start,\n",
-        "        end=scene.end,\n",
-        "        description=scene_description,\n",
-        "        metadata={\n",
-        "            \"camera_view\": camera_view,\n",
-        "            \"action_type\": action_type\n",
-        "        }\n",
-        "    )\n",
-        "    described_scenes.append(described_scene)\n",
-        "\n",
-        "print(f\"Total Scenes Indexed: {len(described_scenes)}\")\n"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -302,11 +252,10 @@
         "id": "Cumx-35JPL_v",
         "outputId": "0afa1cd5-e42d-4cd2-9040-a569170a79ad"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Scene from 0.0s to 2.0s\n",
             "Camera View: road_ahead | Action Type: chasing\n",
@@ -759,10 +708,53 @@
             "Total Scenes Indexed: 148\n"
           ]
         }
+      ],
+      "source": [
+        "from videodb.scene import Scene\n",
+        "\n",
+        "# List to store described scenes\n",
+        "described_scenes = []\n",
+        "\n",
+        "for scene in scenes:\n",
+        "    print(f\"Scene from {scene.start}s to {scene.end}s\")\n",
+        "\n",
+        "    # Generate metadata\n",
+        "    camera_view = scene.describe(\n",
+        "        'Select ONLY one of these camera views (DO NOT describe it, JUST return the category name): [\"road_ahead\", \"helmet_selfie\"]. If the view does not match exactly, pick the closest one.'\n",
+        "    )\n",
+        "\n",
+        "    action_type = scene.describe(\n",
+        "        'Select ONLY one of these options based on the action being performed by the driver (DO NOT describe it, JUST return the category name): [\"clear_road\", \"chasing\"]. If the view does not match exactly, pick the closest one.'\n",
+        "    )\n",
+        "\n",
+        "    scene_description = scene.describe(\n",
+        "        \"Clearly describe a Formula 1 scene by specifying the scene type, the drivers and teams involved, the specific location on the track, and the key action or significance of the moment. Use concise, yet rich language, targeting Formula 1 enthusiasts seeking precise scene descriptions.\"\n",
+        "    )\n",
+        "\n",
+        "    print(f\"Camera View: {camera_view} | Action Type: {action_type}\")\n",
+        "    print(f\"Scene Description: {scene_description}\")\n",
+        "\n",
+        "    # Create Scene object with metadata\n",
+        "    described_scene = Scene(\n",
+        "        video_id=video.id,\n",
+        "        start=scene.start,\n",
+        "        end=scene.end,\n",
+        "        description=scene_description,\n",
+        "        metadata={\n",
+        "            \"camera_view\": camera_view,\n",
+        "            \"action_type\": action_type\n",
+        "        }\n",
+        "    )\n",
+        "    described_scenes.append(described_scene)\n",
+        "\n",
+        "print(f\"Total Scenes Indexed: {len(described_scenes)}\")\n"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "UQsPD3ThIF6D"
+      },
       "source": [
         "## 🗂 Indexing Scenes with Metadata\n",
         "Now that we have **generated metadata** for each scene, we **index them** to make them **searchable**.\n",
@@ -771,21 +763,11 @@
         "✔ **Scene-level metadata makes filtering more effective**.  \n",
         "✔ **Instead of searching the entire video, we only search relevant indexed segments.**  \n",
         "✔ **Future searches can now filter by camera view & driver action.**  \n"
-      ],
-      "metadata": {
-        "id": "UQsPD3ThIF6D"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "if described_scenes:\n",
-        "    scene_index_id = video.index_scenes(\n",
-        "        scenes=described_scenes,\n",
-        "        name=\"F1 Scenes\"\n",
-        "    )\n",
-        "    print(f\"Scenes Indexed under ID: {scene_index_id}\")"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -793,19 +775,29 @@
         "id": "IDwn56ISINIU",
         "outputId": "373d3568-0186-410f-ef7e-cc5bbaeeb602"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Scenes Indexed under ID: 5748b6e4c9b64156\n"
           ]
         }
+      ],
+      "source": [
+        "if described_scenes:\n",
+        "    scene_index_id = video.index_scenes(\n",
+        "        scenes=described_scenes,\n",
+        "        name=\"F1 Scenes\"\n",
+        "    )\n",
+        "    print(f\"Scenes Indexed under ID: {scene_index_id}\")"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "K7ZPGGq3JoFb"
+      },
       "source": [
         "## 🔎 Searching Scenes with Metadata & AI  \n",
         "Now that our scenes are indexed, we can **search using a combination of**:  \n",
@@ -816,13 +808,43 @@
         "\n",
         "#### 🔍 **Example 1: Finding Intense Chasing Moments**  \n",
         "Search for **scenes where a driver is chasing another car**, viewed from the **driver's perspective**.  \n"
-      ],
-      "metadata": {
-        "id": "K7ZPGGq3JoFb"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 422
+        },
+        "id": "lF4LwgyxJsu-",
+        "outputId": "b234ce29-845d-4b8a-fce4-61b1e3dc9513"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "        <iframe\n",
+              "            width=\"800\"\n",
+              "            height=\"400\"\n",
+              "            src=\"https://console.videodb.io/player?url=https://stream.videodb.io/v3/published/manifests/70048f66-7da5-494f-a2cf-00b983539f5e.m3u8\"\n",
+              "            frameborder=\"0\"\n",
+              "            allowfullscreen\n",
+              "            \n",
+              "        ></iframe>\n",
+              "        "
+            ],
+            "text/plain": [
+              "<IPython.lib.display.IFrame at 0x793280c40910>"
+            ]
+          },
+          "execution_count": 21,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "from videodb import IndexType\n",
         "from videodb import SearchType\n",
@@ -837,81 +859,32 @@
         ")\n",
         "# Play the search results\n",
         "search_results.play()"
-      ],
-      "metadata": {
-        "id": "lF4LwgyxJsu-",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 422
-        },
-        "outputId": "b234ce29-845d-4b8a-fce4-61b1e3dc9513"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<IPython.lib.display.IFrame at 0x793280c40910>"
-            ],
-            "text/html": [
-              "\n",
-              "        <iframe\n",
-              "            width=\"800\"\n",
-              "            height=\"400\"\n",
-              "            src=\"https://console.videodb.io/player?url=https://stream.videodb.io/v3/published/manifests/70048f66-7da5-494f-a2cf-00b983539f5e.m3u8\"\n",
-              "            frameborder=\"0\"\n",
-              "            allowfullscreen\n",
-              "            \n",
-              "        ></iframe>\n",
-              "        "
-            ]
-          },
-          "metadata": {},
-          "execution_count": 21
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "097qWtFY4vN6"
+      },
       "source": [
         "#### **🔍 Example 2: Finding Smooth Solo Driving Moments**  \n",
         "Search for **scenes with clean, precise turns**, where the driver has an **open road ahead**.  \n"
-      ],
-      "metadata": {
-        "id": "097qWtFY4vN6"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "search_results = video.search(\n",
-        "    query = \"Smooth turns\",\n",
-        "    filter = [{\"camera_view\": \"road_ahead\"}, {\"action_type\": \"clear_road\"}],   # Using metadata filter\n",
-        "    search_type = SearchType.semantic,\n",
-        "    index_type = IndexType.scene,\n",
-        "    result_threshold = 100,\n",
-        "    scene_index_id = scene_index_id\n",
-        ")\n",
-        "# Play the search results\n",
-        "search_results.play()"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 422
         },
-        "outputId": "b6cd5642-bd9c-4ef2-94e1-1e275339853b",
-        "id": "RZa41OZmzKKl"
+        "id": "RZa41OZmzKKl",
+        "outputId": "b6cd5642-bd9c-4ef2-94e1-1e275339853b"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "<IPython.lib.display.IFrame at 0x793280234390>"
-            ],
             "text/html": [
               "\n",
               "        <iframe\n",
@@ -923,15 +896,34 @@
               "            \n",
               "        ></iframe>\n",
               "        "
+            ],
+            "text/plain": [
+              "<IPython.lib.display.IFrame at 0x793280234390>"
             ]
           },
+          "execution_count": 11,
           "metadata": {},
-          "execution_count": 11
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "search_results = video.search(\n",
+        "    query = \"Smooth turns\",\n",
+        "    filter = [{\"camera_view\": \"road_ahead\"}, {\"action_type\": \"clear_road\"}],   # Using metadata filter\n",
+        "    search_type = SearchType.semantic,\n",
+        "    index_type = IndexType.scene,\n",
+        "    result_threshold = 100,\n",
+        "    scene_index_id = scene_index_id\n",
+        ")\n",
+        "# Play the search results\n",
+        "search_results.play()"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "6ZOyc3Lg484a"
+      },
       "source": [
         "# ✅ Conclusion: Precision Search with Scene Metadata  \n",
         "With **scene-level metadata indexing**, we can:  \n",
@@ -940,10 +932,21 @@
         "✔ **Enhance video retrieval** for F1 analysis, highlights & research.  \n",
         "\n",
         "🚀 **This approach unlocks smarter, metadata-driven video search—making every second of race footage instantly accessible.**  \n"
-      ],
-      "metadata": {
-        "id": "6ZOyc3Lg484a"
-      }
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/real_time_streaming/Road_Monitoring.ipynb
+++ b/real_time_streaming/Road_Monitoring.ipynb
@@ -1,21 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "fVwlZ3taSuZT"
+      },
       "source": [
         "# 🚦 Smart Road Safety Monitoring using VideoDB RTStream\n",
         "\n",
@@ -43,50 +32,50 @@
         "- 🚨 Sending an automatic alert the moment an accident is detected\n",
         "\n",
         "Let's build it!"
-      ],
-      "metadata": {
-        "id": "fVwlZ3taSuZT"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "YOLosD65SxZM"
+      },
       "source": [
         "---\n",
         "\n",
         "## 📦 Step 1: Install Dependencies  \n",
         "\n",
         "We’ll begin by installing the VideoDB."
-      ],
-      "metadata": {
-        "id": "YOLosD65SxZM"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install -q videodb"
-      ],
+      "execution_count": 1,
       "metadata": {
-        "id": "9qXdnI_USvHB",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "9qXdnI_USvHB",
         "outputId": "2cd02992-f51a-4261-feb7-ebb870155c39"
       },
-      "execution_count": 1,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
             "  Building wheel for videodb (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
           ]
         }
+      ],
+      "source": [
+        "!pip install -q videodb"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "x3rCy2flS4Yj"
+      },
       "source": [
         "---\n",
         "## 📦 Step 2: Connect to VideoDB\n",
@@ -96,13 +85,28 @@
         "Please enter your `VIDEO_DB_API_KEY` in the input box that appears below after you run this cell.\n",
         "\n",
         "Your input will be masked.\n"
-      ],
-      "metadata": {
-        "id": "x3rCy2flS4Yj"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "-GXWpXTwS4Fz",
+        "outputId": "d62abf26-c73c-4006-9897-dd8812ec1006"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Please enter your VideoDB API Key: ··········\n",
+            "Connected to VideoDB securely!\n"
+          ]
+        }
+      ],
       "source": [
         "import videodb\n",
         "import os\n",
@@ -116,28 +120,13 @@
         "coll = conn.get_collection()\n",
         "\n",
         "print(\"Connected to VideoDB securely!\")"
-      ],
-      "metadata": {
-        "id": "-GXWpXTwS4Fz",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "d62abf26-c73c-4006-9897-dd8812ec1006"
-      },
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Please enter your VideoDB API Key: ··········\n",
-            "Connected to VideoDB securely!\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "PqyviwxuS_ZL"
+      },
       "source": [
         "---\n",
         "\n",
@@ -145,13 +134,27 @@
         "Connect to the live camera stream monitoring a toll plaza — a high-risk accident location.\n",
         "\n",
         "In this demo, the stream is running at `rtsp://samples.rts.videodb.io:8554/accident`.\n"
-      ],
-      "metadata": {
-        "id": "PqyviwxuS_ZL"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ft_nrviUTEqG",
+        "outputId": "58996897-05ad-4038-cc58-58857e2e5e12"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "RTStream(id=rts-019719e8-f7fb-71c1-bb3d-c4418eefdecd, name=Toll Plaza Accident Stream, collection_id=None, created_at=None, sample_rate=30, status=connected)\n"
+          ]
+        }
+      ],
       "source": [
         "rtsp_url = \"rtsp://samples.rts.videodb.io:8554/accident\"\n",
         "accident_stream = coll.connect_rtstream(\n",
@@ -159,94 +162,82 @@
         "    url=rtsp_url,\n",
         ")\n",
         "print(accident_stream)"
-      ],
-      "metadata": {
-        "id": "ft_nrviUTEqG",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "58996897-05ad-4038-cc58-58857e2e5e12"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "RTStream(id=rts-019719e8-f7fb-71c1-bb3d-c4418eefdecd, name=Toll Plaza Accident Stream, collection_id=None, created_at=None, sample_rate=30, status=connected)\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "Dn1sk6iX6Y80"
+      },
       "source": [
         "\n",
         "#### If you have already connected the stream, run the below cell with the **rtstream id** to reconnect."
-      ],
-      "metadata": {
-        "id": "Dn1sk6iX6Y80"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# accident_stream = coll.get_rtstream(\"\")"
-      ],
+      "execution_count": 3,
       "metadata": {
         "id": "EREENsqo6ZxB"
       },
-      "execution_count": 3,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# accident_stream = coll.get_rtstream(\"\")"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# To stop the stream\n",
-        "# accident_stream.stop()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "_SqudCbN6cua"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# To stop the stream\n",
+        "# accident_stream.stop()"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# To start the stream\n",
-        "# accident_stream.start()"
-      ],
+      "execution_count": 4,
       "metadata": {
         "id": "MZdd-R4s6dDv"
       },
-      "execution_count": 4,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# To start the stream\n",
+        "# accident_stream.start()"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "tG1T-DGCTN_r"
+      },
       "source": [
         "---\n",
         "### 👀 Let us have a look at the toll palza"
-      ],
-      "metadata": {
-        "id": "tG1T-DGCTN_r"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "zvGXp9YQ66U7"
+      },
       "source": [
         "\n",
         "#### 📺 Helper Function: Display Video Stream\n",
         "\n",
         "This cell contains a small utility function to help visualize the video streams with helpful information. You don't need to modify this code."
-      ],
-      "metadata": {
-        "id": "zvGXp9YQ66U7"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "6KyfCkwVTVKj"
+      },
+      "outputs": [],
       "source": [
         "# To display the stream with relevant information\n",
         "\n",
@@ -277,59 +268,34 @@
         "      </div>\n",
         "    </div>\n",
         "    \"\"\")"
-      ],
-      "metadata": {
-        "id": "6KyfCkwVTVKj"
-      },
-      "execution_count": 5,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "yD85ycwD7Dyh"
+      },
       "source": [
         "\n",
         "#### 🔗 Get & Display Recent Stream\n",
         "\n",
         "This cell uses the helper function above to fetch and display the last few minutes of the stream."
-      ],
-      "metadata": {
-        "id": "yD85ycwD7Dyh"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# To get last few minutes stream link\n",
-        "import time\n",
-        "\n",
-        "def fetch_stream(rtstream):\n",
-        "\n",
-        "    now = int(time.time())\n",
-        "    start = int(now - (5 * 60))\n",
-        "    stream_url = rtstream.generate_stream(start, now)\n",
-        "    return stream_url\n",
-        "\n",
-        "video_url = fetch_stream(accident_stream)\n",
-        "\n",
-        "stream_name = \"🚧 Toll Plaza · Accident Detection\"\n",
-        "display_stream(video_url , stream_name)"
-      ],
+      "execution_count": 7,
       "metadata": {
-        "id": "XSwaKQ6FTPg_",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 422
         },
+        "id": "XSwaKQ6FTPg_",
         "outputId": "fe16a3d0-5950-4ce2-ba35-a9fc2fef6167"
       },
-      "execution_count": 7,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
             "text/html": [
               "\n",
               "    <div style=\"position:relative;width:640px;\">\n",
@@ -348,28 +314,65 @@
               "      </div>\n",
               "    </div>\n",
               "    "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
             ]
           },
+          "execution_count": 7,
           "metadata": {},
-          "execution_count": 7
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# To get last few minutes stream link\n",
+        "import time\n",
+        "\n",
+        "def fetch_stream(rtstream):\n",
+        "\n",
+        "    now = int(time.time())\n",
+        "    start = int(now - (5 * 60))\n",
+        "    stream_url = rtstream.generate_stream(start, now)\n",
+        "    return stream_url\n",
+        "\n",
+        "video_url = fetch_stream(accident_stream)\n",
+        "\n",
+        "stream_name = \"🚧 Toll Plaza · Accident Detection\"\n",
+        "display_stream(video_url , stream_name)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "cV38KJbSTZuD"
+      },
       "source": [
         "---\n",
         "## 📦 Step 4: Index Scenes and Detect Accidents  \n",
         "We’ll create a real-time scene index that periodically analyzes video frames and generates natural language descriptions of what’s happening in the stream.\n",
         "\n",
         "The AI will look for visual signs of crashes, vehicle collisions, or people falling down.\n"
-      ],
-      "metadata": {
-        "id": "cV38KJbSTZuD"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "_exbRcxb8KUI",
+        "outputId": "de41aab2-eee5-42da-e0ad-27ea33138b49"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Scene Index ID: c57e9eac387f0414\n"
+          ]
+        }
+      ],
       "source": [
         "from videodb import SceneExtractionType\n",
         "\n",
@@ -385,125 +388,78 @@
         "\n",
         "accident_index_id = accident_scene_index.rtstream_index_id\n",
         "print(\"Scene Index ID:\", accident_index_id)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "_exbRcxb8KUI",
-        "outputId": "de41aab2-eee5-42da-e0ad-27ea33138b49"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Scene Index ID: c57e9eac387f0414\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "FFgY73hB8eMF"
+      },
       "source": [
         "\n",
         "#### If you have already created a scene index, run the below cell with your **scene index id** to reconnect."
-      ],
-      "metadata": {
-        "id": "FFgY73hB8eMF"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# accident_index_id = \"\"\n",
-        "# accident_scene_index = accident_stream.get_scene_index(accident_index_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "k2bA19wr8fGv"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# accident_index_id = \"\"\n",
+        "# accident_scene_index = accident_stream.get_scene_index(accident_index_id)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# To stop the index\n",
-        "# accident_scene_index.stop()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "sXtZzujF8fbl"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# To stop the index\n",
+        "# accident_scene_index.stop()"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# To start the index\n",
-        "# accident_scene_index.start()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "U7TwfLhe8fzl"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# To start the index\n",
+        "# accident_scene_index.start()"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "5UIWFfSJTjqE"
+      },
       "source": [
         "---\n",
         "### Let us see the result of the scene indexing\n"
-      ],
-      "metadata": {
-        "id": "5UIWFfSJTjqE"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "import time\n",
-        "from datetime import datetime\n",
-        "from zoneinfo import ZoneInfo\n",
-        "\n",
-        "def _convert_to_ist(timestamp: float) -> str:\n",
-        "    \"\"\"Convert UTC timestamp to IST (Asia/Kolkata) datetime string.\"\"\"\n",
-        "    return (\n",
-        "        datetime.fromtimestamp(timestamp)\n",
-        "        .astimezone(ZoneInfo(\"Asia/Kolkata\"))\n",
-        "        .strftime(\"%Y-%m-%d %H:%M:%S\")\n",
-        "    )\n",
-        "\n",
-        "def get_scenes(rtstream, index_id):\n",
-        "    # Print indexed scenes\n",
-        "    rtstream_scene_index = rtstream.get_scene_index(index_id)\n",
-        "    scenes = rtstream_scene_index.get_scenes(page_size=5)\n",
-        "    # print(scenes[\"scenes\"][:2])\n",
-        "    if scenes:\n",
-        "        for scene in scenes.get(\"scenes\"):\n",
-        "            start = _convert_to_ist(scene[\"start\"])\n",
-        "            end = _convert_to_ist(scene[\"end\"])\n",
-        "            description = scene[\"description\"]\n",
-        "            print(f\"{start}-{end}: {description}\")\n",
-        "            print(\"-\" * 80)\n",
-        "    else:\n",
-        "        print(\"Scenes not found for given index.\")\n",
-        "\n",
-        "get_scenes(accident_stream, accident_index_id)"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "YVBhVVqqTkwu",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "YVBhVVqqTkwu",
         "outputId": "7d01b178-63a8-4085-f169-23cc6ad68c4a"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "2025-05-29 08:21:54-2025-05-29 08:22:02: **Accident Detected:**\n",
             "\n",
@@ -538,60 +494,107 @@
             "--------------------------------------------------------------------------------\n"
           ]
         }
+      ],
+      "source": [
+        "import time\n",
+        "from datetime import datetime\n",
+        "from zoneinfo import ZoneInfo\n",
+        "\n",
+        "def _convert_to_ist(timestamp: float) -> str:\n",
+        "    \"\"\"Convert UTC timestamp to IST (Asia/Kolkata) datetime string.\"\"\"\n",
+        "    return (\n",
+        "        datetime.fromtimestamp(timestamp)\n",
+        "        .astimezone(ZoneInfo(\"Asia/Kolkata\"))\n",
+        "        .strftime(\"%Y-%m-%d %H:%M:%S\")\n",
+        "    )\n",
+        "\n",
+        "def get_scenes(rtstream, index_id):\n",
+        "    # Print indexed scenes\n",
+        "    rtstream_scene_index = rtstream.get_scene_index(index_id)\n",
+        "    scenes = rtstream_scene_index.get_scenes(page_size=5)\n",
+        "    # print(scenes[\"scenes\"][:2])\n",
+        "    if scenes:\n",
+        "        for scene in scenes.get(\"scenes\"):\n",
+        "            start = _convert_to_ist(scene[\"start\"])\n",
+        "            end = _convert_to_ist(scene[\"end\"])\n",
+        "            description = scene[\"description\"]\n",
+        "            print(f\"{start}-{end}: {description}\")\n",
+        "            print(\"-\" * 80)\n",
+        "    else:\n",
+        "        print(\"Scenes not found for given index.\")\n",
+        "\n",
+        "get_scenes(accident_stream, accident_index_id)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "6rI9zsuHTqrs"
+      },
       "source": [
         "---\n",
         "## 📦 Step 5: Define an Accident Detection Event  \n",
         "Now, we’ll define an event type in the system to detect visual signs of a road accident.\n"
-      ],
-      "metadata": {
-        "id": "6rI9zsuHTqrs"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "i5NRGNOeTsNa",
+        "outputId": "eb2f515f-326b-49af-a1b0-f09888da4352"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Event ID: e1d716cd32a6fbd1\n"
+          ]
+        }
+      ],
       "source": [
         "accident_event_id = conn.create_event(\n",
         "    event_prompt=\"Detect if an accident or vehicle collision takes place.\",\n",
         "    label=\"road_accident\"\n",
         ")\n",
         "print(\"Event ID:\", accident_event_id)"
-      ],
-      "metadata": {
-        "id": "i5NRGNOeTsNa",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "eb2f515f-326b-49af-a1b0-f09888da4352"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Event ID: e1d716cd32a6fbd1\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "KvynpKnQTvlL"
+      },
       "source": [
         "---\n",
         "\n",
         "## 📦 Step 6: Attach an Alert to the Accident Event  \n",
         "Finally, we’ll link a real-time alert to this event. This will send a notification to our webhook the moment an accident is detected.\n"
-      ],
-      "metadata": {
-        "id": "KvynpKnQTvlL"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "5GSOv6k6TwvD",
+        "outputId": "37ce4dfb-3477-46af-b917-0c3e20cdd3ba"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Alert ID: dc2896f3698072e9\n"
+          ]
+        }
+      ],
       "source": [
         "webhook_url = \"\"\n",
         "\n",
@@ -603,27 +606,13 @@
         "  print(\"Alert ID:\", accident_alert_id)\n",
         "else:\n",
         "  print(\"Error: Please provide Webhook URL. Alert cannot be created without it.\")"
-      ],
-      "metadata": {
-        "id": "5GSOv6k6TwvD",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "37ce4dfb-3477-46af-b917-0c3e20cdd3ba"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Alert ID: dc2896f3698072e9\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "UzVBUUc1Tyj8"
+      },
       "source": [
         "---\n",
         "## 📡 Example Alert Payload  \n",
@@ -638,22 +627,14 @@
         "  \"timestamp\": \"2025-05-11T05:35:01.052189+00:00\",\n",
         "  \"start_time\": \"2025-05-11T10:44:59.580915+05:30\",\n",
         "  \"end_time\": \"2025-05-11T10:45:01.504513+05:30\",\n",
-        "  \"stream_url\": \"https://videodb-rt-streaming-service-us-east-1.s3.amazonaws.com/manifests/rts-019677f7-19f9-7e03-9ca8-a920441f2463/1746940499000000-1746940501000000.m3u8?AWSAccessKeyId=ASIAQPKADS32ZNS2LJFY&Signature=HVGiK%2BV4COnKwgS5k9fNc8HZUCU%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEA4aCXVzLWVhc3QtMSJIMEYCIQCdGs1TJm0aLxK6khpPTsOZSNp6ebGkj1qQkUnxNB086wIhAL93q4GyQ%2FxEJewR6maifYWLo4mf5sWT1ZXEW%2BU4CRZUKocDCLf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQAxoMMDMyODgzNTc4NjEzIgwMCodrIkk0HvqKPEEq2wKCbOxF4c4e03FUzHKDjYjA4rNkQ4YWJQ7FcuO0HROsHkHUV3pog3bzoY8a1hYXQSSm2185Q507LEkrqJplStBfozp5ahXsDcS%2FJi%2F2QxiXaT1Ww7wBhedjEqePTeNHiVw0bpXiJpHWBQTQnJ1o0PiLw6c1ytHM9mVk51G81BZxsYdlghoR49Cra5k5vMu2tGYvlrghs1aiV8tZtW7jo3SfK%2FJRhNLYLsGmFoIv3Jabh2Q2WzCyvKTxwDu8%2Fcem0GcbQSVV68e%2BAafUUcaLzf5PjZXdQanz%2Fg%2B%2FSVLi32MLtAhF%2FOyPLGlu5yi3LlbOeznutcnte2XMzlcWUMbZYpVwoqIe2Wkpmbgk44COgTitWwJ4PRIcY6IbvuC1JWjKKnnpXGsJZMFl64f4WuwKKHdu3Xo0HGzg8kJcEFHTFC%2BCRAfpILed40TYIu3IcGqXVNJp9Din%2BbYG7GmLqjCC7oDBBjqdAZXxoutuFqLRrLz9Ai3YchNKgUSi3bL1kNBmv8zUzskiQhwQxFh2OTwbT0ESw9D8rLNRwl27RoAuUzqwy9%2FdO75wQ%2F2dCLwrbhv3QFqiTTWLm3z91EreRdjlZ0vQWT%2FKwdNspyKkegpTVHDj%2BaGVsu4Tig%2BnktBQkHZbIR4yiPXAPMa6eRW7UwFI3jqdo3TO2iU5DxuVa7X8%2Bx07foU%3D&Expires=1747028101\"\n",
+        "  \"stream_url\": \"https://rt.stream.videodb.io/manifests/rts-019719e8-f7fb-71c1-bb3d-c4418eefdecd/1748487351000000-1748487360000000.m3u8\"\n",
         "}\n",
         "```"
-      ],
-      "metadata": {
-        "id": "UzVBUUc1Tyj8"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "alert_stream_url = \"https://rt.stream.videodb.io/manifests/rts-019719e8-f7fb-71c1-bb3d-c4418eefdecd/1748487351000000-1748487360000000.m3u8\"\n",
-        "video_name = \"🚧 Toll Plaza · road_accident\"\n",
-        "\n",
-        "display_stream(alert_stream_url, video_name)"
-      ],
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -662,14 +643,9 @@
         "id": "-XaftWVo979r",
         "outputId": "7f98e9e8-2df1-4e82-d635-572e83303658"
       },
-      "execution_count": 7,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
             "text/html": [
               "\n",
               "    <div style=\"position:relative;width:640px;\">\n",
@@ -688,76 +664,89 @@
               "      </div>\n",
               "    </div>\n",
               "    "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
             ]
           },
+          "execution_count": 7,
           "metadata": {},
-          "execution_count": 7
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "alert_stream_url = \"https://rt.stream.videodb.io/manifests/rts-019719e8-f7fb-71c1-bb3d-c4418eefdecd/1748487351000000-1748487360000000.m3u8\"\n",
+        "video_name = \"🚧 Toll Plaza · road_accident\"\n",
+        "\n",
+        "display_stream(alert_stream_url, video_name)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "JPetvuDq_hiI"
+      },
       "source": [
         "---\n",
         "- Disabling the alert after use"
-      ],
-      "metadata": {
-        "id": "JPetvuDq_hiI"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "accident_scene_index.disable_alert(accident_alert_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "_i6ELvNP_mOS"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "accident_scene_index.disable_alert(accident_alert_id)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "- To re-enable the alert"
-      ],
       "metadata": {
         "id": "5omGHiFj_v5C"
-      }
+      },
+      "source": [
+        "- To re-enable the alert"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "accident_scene_index.enable_alert(accident_alert_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "TFAEaAiI_07W"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "accident_scene_index.enable_alert(accident_alert_id)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "- Let us stop the accident index and proceed with the notebook to explore more possibilities."
-      ],
       "metadata": {
         "id": "2L_qLZ19-lM3"
-      }
+      },
+      "source": [
+        "- Let us stop the accident index and proceed with the notebook to explore more possibilities."
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "accident_scene_index.stop()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "3Rq-HHs5-trc"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "accident_scene_index.stop()"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "KM4T6N7nT2bE"
+      },
       "source": [
         "---\n",
         "## 🚦 Detecting Traffic Rule Violations at the Toll Plaza\n",
@@ -772,13 +761,27 @@
         "---\n",
         "\n",
         "### 📦 Create a New Scene Index for Rule Monitoring  \n"
-      ],
-      "metadata": {
-        "id": "KM4T6N7nT2bE"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dkuuHWvxTzxX",
+        "outputId": "6934ff10-7e58-4fad-8c55-7f43f8466a77"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Scene Index ID: ef827612a22d78b3\n"
+          ]
+        }
+      ],
       "source": [
         "rule_scene_index = accident_stream.index_scenes(\n",
         "    extraction_type=SceneExtractionType.time_based,\n",
@@ -791,54 +794,20 @@
         ")\n",
         "rule_index_id = rule_scene_index.rtstream_index_id\n",
         "print(\"Scene Index ID:\", rule_index_id)\n"
-      ],
-      "metadata": {
-        "id": "dkuuHWvxTzxX",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "6934ff10-7e58-4fad-8c55-7f43f8466a77"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Scene Index ID: ef827612a22d78b3\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "#### Let us list the scene indexes created on our rtstream."
-      ],
       "metadata": {
         "id": "eNMJudng-7_Y"
-      }
+      },
+      "source": [
+        "#### Let us list the scene indexes created on our rtstream."
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "def list_rtstream_indexes(rtstream):\n",
-        "    # List live stream indexes\n",
-        "    rtstream_indexes = rtstream.list_scene_indexes()\n",
-        "    for rtstream_index in rtstream_indexes:\n",
-        "\n",
-        "        print(f\"\"\"RTStreamSceneIndex:\n",
-        "            Index ID       : {rtstream_index.rtstream_index_id}\n",
-        "            RTStream ID    : {rtstream_index.rtstream_id}\n",
-        "            Name           : {rtstream_index.name}\n",
-        "            Status         : {rtstream_index.status}\n",
-        "            Config         : {rtstream_index.extraction_config}\n",
-        "            Prompt         : {rtstream_index.prompt}\n",
-        "        \"\"\")\n",
-        "        print(\"-\" * 80)\n",
-        "\n",
-        "list_rtstream_indexes(accident_stream)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -846,11 +815,10 @@
         "id": "2YcPWmYP_Ppw",
         "outputId": "398ea2a5-5d1d-4089-ba30-4ff099728fa0"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "RTStreamSceneIndex:\n",
             "            Index ID       : c57e9eac387f0414\n",
@@ -872,35 +840,50 @@
             "--------------------------------------------------------------------------------\n"
           ]
         }
+      ],
+      "source": [
+        "def list_rtstream_indexes(rtstream):\n",
+        "    # List live stream indexes\n",
+        "    rtstream_indexes = rtstream.list_scene_indexes()\n",
+        "    for rtstream_index in rtstream_indexes:\n",
+        "\n",
+        "        print(f\"\"\"RTStreamSceneIndex:\n",
+        "            Index ID       : {rtstream_index.rtstream_index_id}\n",
+        "            RTStream ID    : {rtstream_index.rtstream_id}\n",
+        "            Name           : {rtstream_index.name}\n",
+        "            Status         : {rtstream_index.status}\n",
+        "            Config         : {rtstream_index.extraction_config}\n",
+        "            Prompt         : {rtstream_index.prompt}\n",
+        "        \"\"\")\n",
+        "        print(\"-\" * 80)\n",
+        "\n",
+        "list_rtstream_indexes(accident_stream)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "cXP4j0WAT_6a"
+      },
       "source": [
         "---\n",
         "### Let us see the scenes generated"
-      ],
-      "metadata": {
-        "id": "cXP4j0WAT_6a"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "get_scenes(accident_stream, rule_index_id)"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "SktVw1nsUA8f",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "SktVw1nsUA8f",
         "outputId": "b3a82662-dd59-4dc3-fc10-ee51aa5169da"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "2025-05-29 08:32:30-2025-05-29 08:32:33: Based on the image, it appears there has been a significant incident at the toll plaza. Debris is scattered across multiple lanes, and a white vehicle is positioned at an angle, suggesting it may have crashed. The black car in the foreground seems to be approaching the scene cautiously.\n",
             "\n",
@@ -935,58 +918,78 @@
             "--------------------------------------------------------------------------------\n"
           ]
         }
+      ],
+      "source": [
+        "get_scenes(accident_stream, rule_index_id)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "SmOvrJ59UC0y"
+      },
       "source": [
         "---\n",
         "### 📦 Create Event for Traffic Rule Violation  "
-      ],
-      "metadata": {
-        "id": "SmOvrJ59UC0y"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "wztzY0bvUD8G",
+        "outputId": "82eee2a4-07a4-44c9-f799-9369817f7f10"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Event ID: 08da2d1e62a5fca2\n"
+          ]
+        }
+      ],
       "source": [
         "rule_violation_event_id = conn.create_event(\n",
         "    event_prompt=\"Detect if a vehicle breaks traffic rules at the toll plaza.\",\n",
         "    label=\"toll_rule_violation\"\n",
         ")\n",
         "print(\"Event ID:\", rule_violation_event_id)"
-      ],
-      "metadata": {
-        "id": "wztzY0bvUD8G",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "82eee2a4-07a4-44c9-f799-9369817f7f10"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Event ID: 08da2d1e62a5fca2\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "cMJvdtS3UFsi"
+      },
       "source": [
         "---\n",
         "\n",
         "### 📦 Attach an Alert for Rule Violation Detection  "
-      ],
-      "metadata": {
-        "id": "cMJvdtS3UFsi"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ag2Z278rUGsC",
+        "outputId": "3efa8251-0f30-4717-a691-97976c429848"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Alert ID: 31865b33a64e75f5\n"
+          ]
+        }
+      ],
       "source": [
         "# Enter link to your webhook url where you want alerts to go.\n",
         "rule_violation_webhook_url = \"\"\n",
@@ -999,27 +1002,13 @@
         "  print(\"Alert ID:\", rule_violation_alert_id)\n",
         "else:\n",
         "  print(\"Error: Please provide Webhook URL. Alert cannot be created without it.\")"
-      ],
-      "metadata": {
-        "id": "ag2Z278rUGsC",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "3efa8251-0f30-4717-a691-97976c429848"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Alert ID: 31865b33a64e75f5\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "uFPo3v9XUNS-"
+      },
       "source": [
         "---\n",
         "### The following alert was received on the webhook url identifying a potential traffic rule violation\n",
@@ -1035,19 +1024,11 @@
         "  \"stream_url\": \"https://rt.stream.videodb.io/manifests/rts-019719e8-f7fb-71c1-bb3d-c4418eefdecd/1748487883000000-1748487887000000.m3u8\"\n",
         "}\n",
         "```"
-      ],
-      "metadata": {
-        "id": "uFPo3v9XUNS-"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "alert_stream_url = \"https://rt.stream.videodb.io/manifests/rts-019719e8-f7fb-71c1-bb3d-c4418eefdecd/1748487883000000-1748487887000000.m3u8\"\n",
-        "video_name = \"🚧 Toll Plaza · toll_rule_violation\"\n",
-        "\n",
-        "display_stream(alert_stream_url, video_name)"
-      ],
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1056,14 +1037,9 @@
         "id": "HhpsLQ7JF59l",
         "outputId": "d47280b3-da7d-4ae5-e8b5-5278bc29781f"
       },
-      "execution_count": 8,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
             "text/html": [
               "\n",
               "    <div style=\"position:relative;width:640px;\">\n",
@@ -1082,76 +1058,89 @@
               "      </div>\n",
               "    </div>\n",
               "    "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
             ]
           },
+          "execution_count": 8,
           "metadata": {},
-          "execution_count": 8
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "alert_stream_url = \"https://rt.stream.videodb.io/manifests/rts-019719e8-f7fb-71c1-bb3d-c4418eefdecd/1748487883000000-1748487887000000.m3u8\"\n",
+        "video_name = \"🚧 Toll Plaza · toll_rule_violation\"\n",
+        "\n",
+        "display_stream(alert_stream_url, video_name)"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "- Let us stop the alert after use"
-      ],
       "metadata": {
         "id": "Ez8ocDcgADS4"
-      }
+      },
+      "source": [
+        "- Let us stop the alert after use"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "rule_scene_index.disable_alert(rule_violation_alert_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "Z3TcBKVuAG8X"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "rule_scene_index.disable_alert(rule_violation_alert_id)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "- To re-enable the alert"
-      ],
       "metadata": {
         "id": "zqqbpqtzAHoe"
-      }
+      },
+      "source": [
+        "- To re-enable the alert"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "rule_scene_index.enable_alert(rule_violation_alert_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "7cxhddmEAJrf"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "rule_scene_index.enable_alert(rule_violation_alert_id)"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "PFj2miFVU73t"
+      },
       "source": [
         "\n",
         "- Let us stop the present stream and proceed forward in the notebook."
-      ],
-      "metadata": {
-        "id": "PFj2miFVU73t"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "accident_stream.stop()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "VUtF5qtT45NP"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "accident_stream.stop()"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "qXqc_irE5DYR"
+      },
       "source": [
         "---\n",
         "## 🚦 Traffic Congestion Detection: Prevent Traffic Pile-Ups Early\n",
@@ -1164,26 +1153,28 @@
         "It’s important to detect **the very start of a traffic jam** early, so authorities can intervene and resolve it before it spreads.\n",
         "\n",
         "Let's build a system to save your time!"
-      ],
-      "metadata": {
-        "id": "qXqc_irE5DYR"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "V9kQqM8D5JVA"
+      },
       "source": [
         "---\n",
         "\n",
         "## 📦 Step 1: Connect to the Highway Traffic RTSP Stream  \n",
         "\n",
         "We’ll connect a live camera stream monitoring a busy multi-lane highway.\n"
-      ],
-      "metadata": {
-        "id": "V9kQqM8D5JVA"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "CaT_T2CQ5F4H"
+      },
+      "outputs": [],
       "source": [
         "traffic_rtsp_url = \"rtsp://3.6.198.206:8554/traffic\"\n",
         "traffic_stream = coll.connect_rtstream(\n",
@@ -1191,39 +1182,20 @@
         "    url=traffic_rtsp_url,\n",
         ")\n",
         "print(traffic_stream)"
-      ],
-      "metadata": {
-        "id": "CaT_T2CQ5F4H"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "#### Let us list all the rtstreams in our collection."
-      ],
       "metadata": {
         "id": "pEdbjq5gAzZv"
-      }
+      },
+      "source": [
+        "#### Let us list all the rtstreams in our collection."
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "def list_rtstreams():\n",
-        "    for rtstream in coll.list_rtstreams():\n",
-        "        print(f\"\"\"RTStream:\n",
-        "        ID            : {rtstream.id}\n",
-        "        Name          : {rtstream.name}\n",
-        "        Collection ID : {rtstream.collection_id}\n",
-        "        Created At    : {rtstream.created_at}\n",
-        "        Sample Rate   : {rtstream.sample_rate}\n",
-        "        Status        : {rtstream.status}\n",
-        "        \"\"\")\n",
-        "        print(\"-\" * 80)\n",
-        "\n",
-        "list_rtstreams()"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1231,11 +1203,10 @@
         "id": "PZmj9saDA1fA",
         "outputId": "44b86767-82f4-4ef0-8463-49199b682d75"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "RTStream:\n",
             "        ID            : rts-01971a06-eb5c-7453-a257-e0135de60c29\n",
@@ -1293,45 +1264,56 @@
             "--------------------------------------------------------------------------------\n"
           ]
         }
+      ],
+      "source": [
+        "def list_rtstreams():\n",
+        "    for rtstream in coll.list_rtstreams():\n",
+        "        print(f\"\"\"RTStream:\n",
+        "        ID            : {rtstream.id}\n",
+        "        Name          : {rtstream.name}\n",
+        "        Collection ID : {rtstream.collection_id}\n",
+        "        Created At    : {rtstream.created_at}\n",
+        "        Sample Rate   : {rtstream.sample_rate}\n",
+        "        Status        : {rtstream.status}\n",
+        "        \"\"\")\n",
+        "        print(\"-\" * 80)\n",
+        "\n",
+        "list_rtstreams()"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "#### If you have already connected the stream, run the below cell with the **rtstream id** to reconnect."
-      ],
       "metadata": {
         "id": "9hlwyNp76cL3"
-      }
+      },
+      "source": [
+        "#### If you have already connected the stream, run the below cell with the **rtstream id** to reconnect."
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# traffic_stream = coll.get_rtstream(id=\"\")"
-      ],
+      "execution_count": 9,
       "metadata": {
         "id": "OZ-Hg5A45QOJ"
       },
-      "execution_count": 9,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# traffic_stream = coll.get_rtstream(id=\"\")"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "GrtjXIp65Mwn"
+      },
       "source": [
         "---\n",
         "### Let us have a look at the busy lanes"
-      ],
-      "metadata": {
-        "id": "GrtjXIp65Mwn"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "video_url = fetch_stream(traffic_stream)\n",
-        "stream_name = \"🚥 Central Highway · Traffic Detection\"\n",
-        "display_stream(video_url , stream_name)"
-      ],
+      "execution_count": 17,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1340,14 +1322,9 @@
         "id": "ZUg57M-65UrX",
         "outputId": "3a3d72ed-715e-4a3c-f68b-9e8022d4c270"
       },
-      "execution_count": 17,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
             "text/html": [
               "\n",
               "    <div style=\"position:relative;width:640px;\">\n",
@@ -1366,15 +1343,27 @@
               "      </div>\n",
               "    </div>\n",
               "    "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
             ]
           },
+          "execution_count": 17,
           "metadata": {},
-          "execution_count": 17
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "video_url = fetch_stream(traffic_stream)\n",
+        "stream_name = \"🚥 Central Highway · Traffic Detection\"\n",
+        "display_stream(video_url , stream_name)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "2wMP1XBN5XiA"
+      },
       "source": [
         "---\n",
         "## 📦 Step 2: Index Scenes and Detect Traffic Congestion  \n",
@@ -1382,13 +1371,27 @@
         "We’ll create a real-time scene index that periodically analyzes video frames and generates natural language descriptions of what’s happening on the highway.\n",
         "\n",
         "The AI will look for **slow-moving traffic, halted vehicles, or signs of congestion building up**.\n"
-      ],
-      "metadata": {
-        "id": "2wMP1XBN5XiA"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "SA8nc30n5ZyJ",
+        "outputId": "9ca02dc0-c615-4b03-ee7b-b135b0c8a3f2"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Scene Index ID: 403efcbae504de61\n"
+          ]
+        }
+      ],
       "source": [
         "from videodb import SceneExtractionType\n",
         "\n",
@@ -1403,62 +1406,43 @@
         ")\n",
         "traffic_jam_index_id = traffic_jam_scene_index.rtstream_index_id\n",
         "print(\"Scene Index ID:\", traffic_jam_index_id)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "SA8nc30n5ZyJ",
-        "outputId": "9ca02dc0-c615-4b03-ee7b-b135b0c8a3f2"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Scene Index ID: 403efcbae504de61\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "d819cxWM-CNq"
+      },
       "source": [
         "\n",
         "#### If you have already created a scene index, run the below cell with your **scene index id** to reconnect."
-      ],
-      "metadata": {
-        "id": "d819cxWM-CNq"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# traffic_index_id = \"\"\n",
-        "# traffic_scene_index = traffic_stream.get_scene_index(traffic_index_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "GBm3UYiO-Hlc"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# traffic_index_id = \"\"\n",
+        "# traffic_scene_index = traffic_stream.get_scene_index(traffic_index_id)"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "-tFI4QjB5dGw"
+      },
       "source": [
         "---\n",
         "### Let us see the indexes being generated"
-      ],
-      "metadata": {
-        "id": "-tFI4QjB5dGw"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "get_scenes(traffic_stream , traffic_jam_index_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1466,11 +1450,10 @@
         "id": "14lqxoQO5mty",
         "outputId": "92f49be8-d65f-4071-994a-662e99b58824"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "2025-05-29 13:08:29-2025-05-29 13:08:34: Based on the provided video frames, the classification is:\n",
             "\n",
@@ -1519,31 +1502,27 @@
             "--------------------------------------------------------------------------------\n"
           ]
         }
+      ],
+      "source": [
+        "get_scenes(traffic_stream , traffic_jam_index_id)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "eUAhAFuV5rNK"
+      },
       "source": [
         "---\n",
         "\n",
         "## 📦 Step 3: Create Event and Attach Alert for Traffic Jam Detection  \n",
         "\n",
         "We’ll now define a single event for detecting traffic congestion and immediately attach a real-time alert to it.\n"
-      ],
-      "metadata": {
-        "id": "eUAhAFuV5rNK"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Creating Event\n",
-        "traffic_event_id = conn.create_event(\n",
-        "    event_prompt=\"Detect if traffic congestion or jam is forming.\",\n",
-        "    label=\"traffic_congestion\"\n",
-        ")\n",
-        "print(\"Event ID:\", traffic_event_id)\n"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1551,19 +1530,43 @@
         "id": "Dp22xgVM5rff",
         "outputId": "e4080dba-2028-44a4-d241-b5ba2befd8ef"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Event ID: c0f7b39718b545d9\n"
           ]
         }
+      ],
+      "source": [
+        "# Creating Event\n",
+        "traffic_event_id = conn.create_event(\n",
+        "    event_prompt=\"Detect if traffic congestion or jam is forming.\",\n",
+        "    label=\"traffic_congestion\"\n",
+        ")\n",
+        "print(\"Event ID:\", traffic_event_id)\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Nq3RYvbd5uF_",
+        "outputId": "1039656c-04c8-4c0a-f536-6bf766d73f0b"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Alert ID: 140d39c7bb9596ca\n"
+          ]
+        }
+      ],
       "source": [
         "# Enter link to your webhook url where you want alerts to go. You can create one simply on pipedream.\n",
         "traffic_webhook_url = \"\"\n",
@@ -1576,27 +1579,13 @@
         "  print(\"Alert ID:\", traffic_alert_id)\n",
         "else:\n",
         "  print(\"Error: Please provide Webhook URL. Alert cannot be created without it.\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Nq3RYvbd5uF_",
-        "outputId": "1039656c-04c8-4c0a-f536-6bf766d73f0b"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Alert ID: 140d39c7bb9596ca\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "heBIhjiu5xNp"
+      },
       "source": [
         "\n",
         "---\n",
@@ -1617,29 +1606,21 @@
         "  \"stream_url\": \"https://rt.stream.videodb.io/manifests/rts-01971a06-eb5c-7453-a257-e0135de60c29/1748504468000000-1748504473000000.m3u8\"\n",
         "}\n",
         "```"
-      ],
-      "metadata": {
-        "id": "heBIhjiu5xNp"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "q6YG-iP1_UUj"
+      },
       "source": [
         "---\n",
         "### Let us have a look at the stream_url received in the alert."
-      ],
-      "metadata": {
-        "id": "q6YG-iP1_UUj"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "alert_stream_url = \"https://rt.stream.videodb.io/manifests/rts-01971a06-eb5c-7453-a257-e0135de60c29/1748504468000000-1748504473000000.m3u8\"\n",
-        "video_name = \"🚥 Central Highway · traffic_congestion\"\n",
-        "\n",
-        "display_stream(alert_stream_url, video_name)"
-      ],
+      "execution_count": 12,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1648,14 +1629,9 @@
         "id": "WXU-Db0z_T2S",
         "outputId": "36a64ffd-824a-409f-ee5e-32b2e448a803"
       },
-      "execution_count": 12,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
             "text/html": [
               "\n",
               "    <div style=\"position:relative;width:640px;\">\n",
@@ -1674,75 +1650,88 @@
               "      </div>\n",
               "    </div>\n",
               "    "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
             ]
           },
+          "execution_count": 12,
           "metadata": {},
-          "execution_count": 12
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "alert_stream_url = \"https://rt.stream.videodb.io/manifests/rts-01971a06-eb5c-7453-a257-e0135de60c29/1748504468000000-1748504473000000.m3u8\"\n",
+        "video_name = \"🚥 Central Highway · traffic_congestion\"\n",
+        "\n",
+        "display_stream(alert_stream_url, video_name)"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "- Let us disable the alert after use"
-      ],
       "metadata": {
         "id": "jfKNjz4qAi6H"
-      }
+      },
+      "source": [
+        "- Let us disable the alert after use"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "traffic_jam_scene_index.disable_alert(traffic_alert_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "f8TG8V9KAlUG"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "traffic_jam_scene_index.disable_alert(traffic_alert_id)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "- To re-enable the alert"
-      ],
       "metadata": {
         "id": "s5Mp7YBmAqq9"
-      }
+      },
+      "source": [
+        "- To re-enable the alert"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "traffic_jam_scene_index.enable_alert(traffic_alert_id)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "bKQ2uq3jAsam"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "traffic_jam_scene_index.enable_alert(traffic_alert_id)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "- We should stop the stream after use"
-      ],
       "metadata": {
         "id": "Bx832H6EAzH_"
-      }
+      },
+      "source": [
+        "- We should stop the stream after use"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "traffic_stream.stop()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "8MXq3pCDA3nH"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "traffic_stream.stop()"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "4FkFVPpC50Sf"
+      },
       "source": [
         "---\n",
         "\n",
@@ -1770,10 +1759,21 @@
         "- 🚁 **Drone-based surveillance for rural highways, border roads, or disaster-affected zones.**\n",
         "\n",
         "Where would *you* deploy it next?"
-      ],
-      "metadata": {
-        "id": "4FkFVPpC50Sf"
-      }
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
This PR includes a couple of minor fixes to improve clarity and usability in the example notebooks:
- Updated the example stream_url in the road monitoring notebook to use the production URL instead of the dev one.
- Added the "Open in Colab" button to the scene_level_metadata_indexing.ipynb notebook for easier one-click experimentation.