### PR TITLE
Add Sandbox Compute quickstart notebook

### DIFF
--- a/guides/sandbox/quickstart.ipynb
+++ b/guides/sandbox/quickstart.ipynb
@@ -1,0 +1,958 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "85b4a36c",
+   "metadata": {},
+   "source": [
+    "# Sandbox Compute — Quickstart\n",
+    "\n",
+    "**Sandbox Compute** lets you run supported open-weight models (Gemma, Qwen, Whisper, OmniVoice, FLUX, RT-DETR, …) on dedicated, warm GPU compute inside your VideoDB workflows. You create a *sandbox*, wait until it's active, then pass its `sandbox_id` to any supported API — VideoDB routes that job to your sandbox instead of the default hosted path.\n",
+    "\n",
+    "This notebook walks through the full surface end to end:\n",
+    "\n",
+    "| Step | What it shows |\n",
+    "|---|---|\n",
+    "| **Setup** | Install the SDK, connect to dev |\n",
+    "| **1. Lifecycle** | Create, wait, retrieve, list a sandbox |\n",
+    "| **2. Media** | Upload one sample video reused by the understanding steps |\n",
+    "| **3. Text** | `generate_text` — Qwen |\n",
+    "| **4. Visual understanding** | `video.understand` (VLM) — Qwen |\n",
+    "| **5. Object detection** | `video.understand` — RT-DETR |\n",
+    "| **6. Text-to-speech** | `generate_voice` — OmniVoice |\n",
+    "| **7. Image generation** | `generate_image` — FLUX |\n",
+    "| **Cleanup** | Stop the sandbox |\n",
+    "\n",
+    "### Key concepts\n",
+    "- **Tier** — sandbox size (`small` / `medium`). Pick the smallest tier that supports your **largest** model. FLUX needs `medium`, so this notebook uses `medium`.\n",
+    "- **`sandbox_id` routing** — pass it to select your warm sandbox; omit it to use VideoDB's default hosted models.\n",
+    "- **Sync vs async** — text & understanding return results directly; generation (voice/image) returns a **job** you `wait()` on.\n",
+    "\n",
+    "> 💸 **A running sandbox consumes compute.** Keep it active while you run the workload sections, then run the final **Cleanup** cell to release it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "129fc79c",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "### Install the SDK\n",
+    "Install the VideoDB SDK (**`videodb==0.5.2`**), which includes the Sandbox interface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "58694f2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.1.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install -q videodb==0.5.2 python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90f4fd93",
+   "metadata": {},
+   "source": [
+    "### Connect to VideoDB dev\n",
+    "Uses a dev API key entered securely and connects explicitly to the dev endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7aea060f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to VideoDB\n"
+     ]
+    }
+   ],
+   "source": [
+    "from getpass import getpass\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "from videodb import connect\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "api_key = getpass(\"Enter your VideoDB API key: \")\n",
+    "if not api_key:\n",
+    "    raise ValueError(\"A VideoDB API key is required.\")\n",
+    "\n",
+    "conn = connect(api_key=api_key)\n",
+    "collection = conn.get_collection()\n",
+    "print(\"Connected to VideoDB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97422ff5",
+   "metadata": {},
+   "source": [
+    "## 1. Sandbox lifecycle\n",
+    "\n",
+    "A **sandbox** is a dedicated pool of warm GPU compute holding one or more models. You create it once and reuse it across every compatible job below.\n",
+    "\n",
+    "### Create a sandbox\n",
+    "We request all four models this notebook uses. FLUX requires the `medium` tier, and `medium` also covers the others, so we create a single `medium` sandbox.\n",
+    "\n",
+    "> The SDK's `SandboxTier` is imported from `videodb`; model names are plain strings (see the [model catalog](https://docs.videodb.io) for the full list + minimum tiers)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f0cf1daf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sandbox ID: bx-13832c0a9e4f4fa9\n",
+      "Status: provisioning\n",
+      "Tier: medium\n",
+      "Models: ['Qwen/Qwen3.5-9B', 'rtdetr-v2-r50vd', 'k2-fsa/OmniVoice', 'black-forest-labs/FLUX.1-dev']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "from videodb import SandboxTier\n",
+    "\n",
+    "# Model IDs (plain strings — see the sandbox model catalog).\n",
+    "TEXT_AND_VISION_MODEL = \"Qwen/Qwen3.5-9B\"          # text + vision (VLM)\n",
+    "OBJECT_DETECTION_MODEL = \"rtdetr-v2-r50vd\"          # object detection\n",
+    "TTS_MODEL = \"k2-fsa/OmniVoice\"                      # text-to-speech\n",
+    "IMAGE_GENERATION_MODEL = \"black-forest-labs/FLUX.1-dev\"  # image generation\n",
+    "\n",
+    "SANDBOX_TIER = SandboxTier.medium\n",
+    "SANDBOX_MODELS = [\n",
+    "    TEXT_AND_VISION_MODEL,\n",
+    "    OBJECT_DETECTION_MODEL,\n",
+    "    TTS_MODEL,\n",
+    "    IMAGE_GENERATION_MODEL,\n",
+    "]\n",
+    "SANDBOX_NAME = f\"sandbox-cookbook-{datetime.now(timezone.utc):%Y%m%d-%H%M%S}\"\n",
+    "\n",
+    "sandbox = conn.create_sandbox(\n",
+    "    tier=SANDBOX_TIER,\n",
+    "    name=SANDBOX_NAME,\n",
+    "    models=SANDBOX_MODELS,\n",
+    ")\n",
+    "\n",
+    "print(\"Sandbox ID:\", sandbox.id)\n",
+    "print(\"Status:\", sandbox.status)\n",
+    "print(\"Tier:\", sandbox.tier)\n",
+    "print(\"Models:\", sandbox.models)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7c4cb9b",
+   "metadata": {},
+   "source": [
+    "### Wait until the sandbox is active\n",
+    "Creation returns immediately while compute provisions in the background. Submit jobs only after `wait_for_ready()` returns.\n",
+    "\n",
+    "The SDK treats both `active` and `alert` as ready. `alert` can mean only *part* of a multi-model sandbox came up — so the per-workload cells below remain the authoritative check for each model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "50561081",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sandbox ID: bx-13832c0a9e4f4fa9\n",
+      "Status: active\n",
+      "Ready: True\n",
+      "Active: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "sandbox.wait_for_ready(timeout=1200, interval=5)\n",
+    "\n",
+    "print(\"Sandbox ID:\", sandbox.id)\n",
+    "print(\"Status:\", sandbox.status)\n",
+    "print(\"Ready:\", sandbox.is_ready)\n",
+    "print(\"Active:\", sandbox.is_active)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8ea5cb0",
+   "metadata": {},
+   "source": [
+    "### Retrieve and list sandboxes\n",
+    "`get_sandbox(id)` fetches a sandbox by ID; `refresh()` pulls the latest server state; `list_sandboxes()` enumerates them (optionally filtered by status)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "bb3560cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Retrieved: {'id': 'bx-13832c0a9e4f4fa9', 'name': 'sandbox-cookbook-20260725-042808', 'tier': 'medium', 'status': 'active', 'models': ['Qwen/Qwen3.5-9B', 'rtdetr-v2-r50vd', 'k2-fsa/OmniVoice', 'black-forest-labs/FLUX.1-dev']}\n",
+      "All sandboxes: 20\n",
+      "Active sandbox IDs: ['bx-13832c0a9e4f4fa9', 'bx-015fd8939f184276']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Retrieve a single sandbox by ID and refresh its state\n",
+    "same_sandbox = conn.get_sandbox(sandbox.id)\n",
+    "same_sandbox.refresh()\n",
+    "print(\"Retrieved:\", {\n",
+    "    \"id\": same_sandbox.id,\n",
+    "    \"name\": same_sandbox.name,\n",
+    "    \"tier\": same_sandbox.tier,\n",
+    "    \"status\": same_sandbox.status,\n",
+    "    \"models\": same_sandbox.models,\n",
+    "})\n",
+    "\n",
+    "# List all / active sandboxes\n",
+    "all_sandboxes = conn.list_sandboxes()\n",
+    "active_sandboxes = conn.list_sandboxes(status=\"active\")\n",
+    "print(\"All sandboxes:\", len(all_sandboxes))\n",
+    "print(\"Active sandbox IDs:\", [item.id for item in active_sandboxes])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed4bb854",
+   "metadata": {},
+   "source": [
+    "## 2. Prepare shared test media\n",
+    "\n",
+    "The visual-understanding and object-detection steps reuse one short public video. `upload()` waits for ingestion and returns a `Video`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e1304fbf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collection ID: c-7a9dacb6-2ff3-481a-aef7-bc747ba89340\n",
+      "Video ID: m-z-019f9796-8ff5-7963-b2ba-fe344c310f7c\n",
+      "Video length: 18.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "SAMPLE_VIDEO_URL = \"https://www.youtube.com/watch?v=jNQXAC9IVRw\"\n",
+    "\n",
+    "video = collection.upload(\n",
+    "    url=SAMPLE_VIDEO_URL,\n",
+    "    name=\"Sandbox cookbook sample\",\n",
+    ")\n",
+    "\n",
+    "print(\"Collection ID:\", collection.id)\n",
+    "print(\"Video ID:\", video.id)\n",
+    "print(\"Video length:\", video.length)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80102019",
+   "metadata": {},
+   "source": [
+    "## 3. Text generation — Qwen\n",
+    "\n",
+    "The smallest end-to-end check: pass `model_name` + `sandbox_id` and the server validates the sandbox, routes the completion to your warm Qwen, and returns text directly (synchronous).\n",
+    "\n",
+    "> **Reasoning models:** Qwen3-family models can emit `<think>…</think>` reasoning. If you only see reasoning, raise `max_tokens` (done here) so the final answer isn't truncated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d7e053c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: Qwen/Qwen3.5-9B\n",
+      "Response:\n",
+      " {'output': 'Thinking Process:\\n\\n1.  **Analyze the Request:**\\n    *   Topic: Dedicated inference compute for video AI workflows.\\n    *   Format: Three concise bullet points.\\n    *   Goal: Explain why it is useful.\\n\\n2.  **Identify Key Benefits of Dedicated Inference Compute for Video AI:**\\n    *   Video AI is computationally intensive (high resolution, high frame rates, complex models).\\n    *   Latency matters (real-time or near real-time processing).\\n    *   Cost/Efficiency (GPU utilization, avoiding shared resource contention).\\n    *   Reliability/Consistency (SLA, predictable performance).\\n    *   Scalability (handling bursts of traffic).\\n\\n3.  **Draft Initial Points:**\\n    *   Video processing needs a lot of power, so dedicated GPUs help speed it up.\\n    *   It reduces latency so you can process video in real-time without waiting.\\n    *   It saves money because you don\\'t pay for shared resources that might be idle.\\n\\n4.  **Refine for Conciseness and Impact (Iterative Process):**\\n    *   *Draft 1:* Video AI requires massive processing power, so dedicated compute ensures high throughput without bottlenecks.\\n    *   *Draft 2:* Low latency is crucial for real-time applications, and dedicated hardware provides consistent performance.\\n    *   *Draft 3:* Cost efficiency is better because you don\\'t share resources with other workloads.\\n\\n5.  **Select the Top Three (Focusing on Performance, Latency, and Cost/Reliability):**\\n    *   Point 1: Performance/Throughput (Video is heavy).\\n    *   Point 2: Latency/Real-time capability (Critical for streaming/interaction).\\n    *   Point 3: Cost/Resource Efficiency (Avoiding contention).\\n\\n6.  **Final Polish (Checking constraints: \"concise bullet points\"):**\\n    *   *Bullet 1:* High computational throughput handles the massive data loads of high-resolution, multi-frame video processing without bottlenecks.\\n    *   *Bullet 2:* Low-latency performance ensures real-time inference capabilities, critical for interactive applications like live streaming or autonomous systems.\\n    *   *Bullet 3:* Isolated resources eliminate contention from shared workloads, guaranteeing consistent SLAs and optimizing cost-per-inference.\\n\\n7.  **Final Review against constraints:**\\n    *'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "text_response = collection.generate_text(\n",
+    "    prompt=(\n",
+    "        \"In three concise bullet points, explain why dedicated inference \"\n",
+    "        \"compute is useful for video AI workflows.\"\n",
+    "    ),\n",
+    "    model_name=TEXT_AND_VISION_MODEL,\n",
+    "    sandbox_id=sandbox.id,\n",
+    "    max_tokens=512,\n",
+    "    temperature=0.2,\n",
+    ")\n",
+    "\n",
+    "print(\"Model:\", TEXT_AND_VISION_MODEL)\n",
+    "print(\"Response:\\n\", text_response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8550bd06",
+   "metadata": {},
+   "source": [
+    "## 4. Visual understanding (VLM) — Qwen\n",
+    "\n",
+    "`video.understand()` samples frames and asks the sandbox-backed VLM to describe them. Routing is via `sandbox_id` + `model` **inside the analyzer config**. This is the public sandbox path for image understanding today."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "7b93cde7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Understanding ID: und_756b00fa991d464f\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'metadata': {},\n",
+       " 'name': 'scene_description',\n",
+       " 'scenes': [{'data': {'text': 'There are no people, objects, setting, or actions visible in these images. The images display a single, repeated photograph of a gold-colored speaker grille, likely from a high-fidelity audio system. The grille features a series of concentric, angular cutouts designed to allow sound to pass through while protecting the internal components. The background is a uniform, light beige or off-white color, providing a neutral backdrop that emphasizes the metallic sheen and geometric pattern of the grille. There is no indication of movement, context, or activity within the frame.'},\n",
+       "   'end': None,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene_000000',\n",
+       "   'start': None},\n",
+       "  {'data': {'text': 'There are no people, objects, setting, or actions visible in the provided image. The image displays a single, repeated graphic element: a gold-colored, geometric pattern resembling a stylized \"X\" or cross, set against a white background. This pattern appears to be a decorative border or frame design, not a scene with content.'},\n",
+       "   'end': None,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene_000001',\n",
+       "   'start': None},\n",
+       "  {'data': {'text': 'The provided images are identical and show a close-up of a single object: a diamond-shaped speaker grille.\\n\\n- **Object:** The image displays the central part of a speaker, specifically its grille. The grille is made of a metallic material, likely aluminum or steel, with a series of concentric, V-shaped grooves radiating from the center. These grooves are designed to allow sound to pass through while protecting the internal components. The color of the grille is a muted, metallic gray or silver.\\n- **Setting:** The setting is not visible. The image is a tight, cropped shot that fills the entire frame with the speaker grille, providing no context for its location or surroundings.\\n- **People:** There are no people visible in the image.\\n- **Actions:** There are no actions depicted, as the image is a static, still photograph of an inanimate object.'},\n",
+       "   'end': None,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene_000002',\n",
+       "   'start': None},\n",
+       "  {'data': {'text': 'There are no people, objects, setting, or actions visible in the image. The image displays a single, static object: a square-shaped, gold-colored speaker grille with a geometric pattern of cutouts. It appears to be a product shot against a plain white background.'},\n",
+       "   'end': None,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene_000003',\n",
+       "   'start': None},\n",
+       "  {'data': {'text': 'The provided images are identical and show a single object: a square, gold-colored speaker grille.\\n\\n- **Object:** A speaker grille with a geometric pattern of interlocking shapes. The frame is metallic and has a brushed or matte finish.\\n- **Setting:** The grille is displayed against a plain, light-colored background, likely for product photography.\\n- **Actions:** There are no people or actions visible in the image. The object is stationary.'},\n",
+       "   'end': None,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene_000004',\n",
+       "   'start': None},\n",
+       "  {'data': {'text': 'There are no people, objects, setting, or actions visible in the image. The image displays a single, static object: a gold-colored, rectangular speaker grille with a mesh pattern. It appears to be a product shot against a plain white background.'},\n",
+       "   'end': None,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene_000005',\n",
+       "   'start': None}],\n",
+       " 'status': 'done',\n",
+       " 'type': 'vlm'}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "visual_understanding = video.understand(\n",
+    "    segmentation={\"type\": \"time\", \"seconds\": 8},\n",
+    "    sampling={\"strategy\": \"uniform\", \"frame_count\": 3},\n",
+    "    analyzers=[\n",
+    "        {\n",
+    "            \"type\": \"vlm\",\n",
+    "            \"name\": \"scene_description\",\n",
+    "            \"config\": {\n",
+    "                \"model\": TEXT_AND_VISION_MODEL,\n",
+    "                \"sandbox_id\": sandbox.id,\n",
+    "                \"prompt\": (\n",
+    "                    \"Describe the people, objects, setting, and actions visible \"\n",
+    "                    \"in these images. Be concise and factual.\"\n",
+    "                ),\n",
+    "                \"temperature\": 0.1,\n",
+    "                \"max_output_tokens\": 300,\n",
+    "            },\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "visual_understanding.wait_until_complete(timeout=1800, poll_interval=10)\n",
+    "if not visual_understanding.is_successful:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Visual understanding failed with status {visual_understanding.status}\"\n",
+    "    )\n",
+    "\n",
+    "visual_output = visual_understanding.get_analyzer(\"scene_description\").get_output()\n",
+    "print(\"Understanding ID:\", visual_understanding.id)\n",
+    "visual_output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85397db6",
+   "metadata": {},
+   "source": [
+    "## 5. Object detection — RT-DETR\n",
+    "\n",
+    "Same `video.understand()` surface with an `object_detection` analyzer. Output is normalized detections (labels, counts, optional bounding boxes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "861bc181",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Understanding ID: und_1f4fc125b8ed47f1\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'metadata': {},\n",
+       " 'name': 'objects',\n",
+       " 'scenes': [{'data': {'frames': [{'detections': [{'box': [0.1024,\n",
+       "         0.1482,\n",
+       "         0.9438,\n",
+       "         0.9976],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.9213},\n",
+       "       {'box': [0.6643, 0.0838, 0.9992, 0.5668],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.8713},\n",
+       "       {'box': [0.4512, 0.1106, 0.7457, 0.5159],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.5105}],\n",
+       "      'frame_id': 'frame-scene-0.000-8.000-2.000',\n",
+       "      'timestamp_sec': 2.0},\n",
+       "     {'detections': [{'box': [0.6586, 0.1268, 1.0, 0.5978],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.8801},\n",
+       "       {'box': [0.1575, 0.2595, 0.8746, 0.9975],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.8629},\n",
+       "       {'box': [0.5979, 0.6386, 0.8587, 0.9993],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'handbag',\n",
+       "        'score': 0.5475},\n",
+       "       {'box': [0.1659, 0.6369, 0.778, 0.9992],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.4866},\n",
+       "       {'box': [0.1599, 0.6382, 0.849, 0.9995],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.4092}],\n",
+       "      'frame_id': 'frame-scene-0.000-8.000-4.000',\n",
+       "      'timestamp_sec': 4.0},\n",
+       "     {'detections': [{'box': [0.6144, 0.1061, 0.9991, 0.5848],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.9144},\n",
+       "       {'box': [0.1438, 0.1847, 0.9092, 0.9978],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.9119},\n",
+       "       {'box': [0.4036, 0.1257, 0.7002, 0.5268],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.8395}],\n",
+       "      'frame_id': 'frame-scene-0.000-8.000-6.000',\n",
+       "      'timestamp_sec': 6.0}],\n",
+       "    'summary': {'counts': {'backpack': 2,\n",
+       "      'elephant': 5,\n",
+       "      'handbag': 1,\n",
+       "      'person': 3},\n",
+       "     'labels': ['backpack', 'elephant', 'handbag', 'person'],\n",
+       "     'max_scores': {'backpack': 0.4866,\n",
+       "      'elephant': 0.9144,\n",
+       "      'handbag': 0.5475,\n",
+       "      'person': 0.9213}}},\n",
+       "   'end': 8.0,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene-0.000-8.000',\n",
+       "   'start': 0.0},\n",
+       "  {'data': {'frames': [{'detections': [{'box': [0.0468,\n",
+       "         0.1619,\n",
+       "         0.9125,\n",
+       "         0.9976],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.9048},\n",
+       "       {'box': [0.6473, 0.1359, 0.9998, 0.6012],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.8146},\n",
+       "       {'box': [0.7867, 0.1335, 1.0, 0.5876],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.5562},\n",
+       "       {'box': [0.6476, 0.1435, 0.8721, 0.613],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.5158}],\n",
+       "      'frame_id': 'frame-scene-8.000-16.000-10.000',\n",
+       "      'timestamp_sec': 10.0},\n",
+       "     {'detections': [{'box': [0.0927, 0.1474, 0.9346, 0.9977],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.9315},\n",
+       "       {'box': [0.6676, 0.1186, 0.9999, 0.5741],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.5518},\n",
+       "       {'box': [0.6698, 0.1177, 0.8951, 0.5886],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.442},\n",
+       "       {'box': [0.6698, 0.1177, 0.8951, 0.5886],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.4237},\n",
+       "       {'box': [0.0002, 0.7713, 1.0, 0.9987],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'bench',\n",
+       "        'score': 0.388},\n",
+       "       {'box': [0.6304, 0.5835, 0.9338, 0.9997],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'handbag',\n",
+       "        'score': 0.383}],\n",
+       "      'frame_id': 'frame-scene-8.000-16.000-12.000',\n",
+       "      'timestamp_sec': 12.0},\n",
+       "     {'detections': [{'box': [0.1926, 0.1319, 0.9254, 0.9971],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.9204},\n",
+       "       {'box': [0.6606, 0.1053, 0.9993, 0.5756],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.6985},\n",
+       "       {'box': [0.6616, 0.1069, 0.8896, 0.5789],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.5198},\n",
+       "       {'box': [0.8447, 0.0937, 0.9999, 0.5448],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.3917},\n",
+       "       {'box': [0.8573, 0.1377, 0.9996, 0.5455],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.3878},\n",
+       "       {'box': [0.2018, 0.5739, 0.7397, 0.9979],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.3856},\n",
+       "       {'box': [0.8054, 0.1, 0.9997, 0.549],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.3806},\n",
+       "       {'box': [0.9291, 0.162, 1.0, 0.5433],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.3736},\n",
+       "       {'box': [0.1945, 0.6305, 0.3648, 0.9999],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.3661},\n",
+       "       {'box': [0.2486, 0.0013, 0.6878, 0.3361],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'train',\n",
+       "        'score': 0.3508}],\n",
+       "      'frame_id': 'frame-scene-8.000-16.000-14.000',\n",
+       "      'timestamp_sec': 14.0}],\n",
+       "    'summary': {'counts': {'backpack': 2,\n",
+       "      'bench': 1,\n",
+       "      'elephant': 11,\n",
+       "      'handbag': 1,\n",
+       "      'person': 4,\n",
+       "      'train': 1},\n",
+       "     'labels': ['backpack', 'bench', 'elephant', 'handbag', 'person', 'train'],\n",
+       "     'max_scores': {'backpack': 0.3856,\n",
+       "      'bench': 0.388,\n",
+       "      'elephant': 0.8146,\n",
+       "      'handbag': 0.383,\n",
+       "      'person': 0.9315,\n",
+       "      'train': 0.3508}}},\n",
+       "   'end': 16.0,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene-8.000-16.000',\n",
+       "   'start': 8.0},\n",
+       "  {'data': {'frames': [{'detections': [{'box': [0.621, 0.1218, 0.9987, 0.5882],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.9037},\n",
+       "       {'box': [0.1738, 0.167, 0.8886, 0.9973],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.8878},\n",
+       "       {'box': [0.3288, 0.1362, 0.4928, 0.5042],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.535},\n",
+       "       {'box': [0.3282, 0.1357, 0.5528, 0.5034],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.4949},\n",
+       "       {'box': [0.8665, 0.156, 0.9977, 0.5577],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.4533},\n",
+       "       {'box': [0.617, 0.623, 0.8622, 0.9983],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'handbag',\n",
+       "        'score': 0.4004}],\n",
+       "      'frame_id': 'frame-scene-16.000-18.947-16.737',\n",
+       "      'timestamp_sec': 16.737},\n",
+       "     {'detections': [{'box': [0.1189, 0.1664, 0.8595, 0.9973],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.9201},\n",
+       "       {'box': [0.6155, 0.1318, 1.0, 0.6038],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.9031},\n",
+       "       {'box': [0.2375, 0.6124, 0.763, 0.9967],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.5272},\n",
+       "       {'box': [0.1223, 0.6087, 0.7599, 0.998],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.4086},\n",
+       "       {'box': [0.122, 0.6308, 0.3473, 0.9988],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.402},\n",
+       "       {'box': [0.5989, 0.6071, 0.8578, 0.9992],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'handbag',\n",
+       "        'score': 0.3694},\n",
+       "       {'box': [0.3678, 0.1517, 0.6738, 0.5569],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.3626}],\n",
+       "      'frame_id': 'frame-scene-16.000-18.947-17.474',\n",
+       "      'timestamp_sec': 17.474},\n",
+       "     {'detections': [{'box': [0.1505, 0.1705, 0.8463, 0.9968],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'person',\n",
+       "        'score': 0.9105},\n",
+       "       {'box': [0.6234, 0.1393, 0.8304, 0.6027],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.6275},\n",
+       "       {'box': [0.744, 0.1286, 0.9993, 0.5737],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.6153},\n",
+       "       {'box': [0.8688, 0.1757, 0.9994, 0.571],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.6},\n",
+       "       {'box': [0.6256, 0.1342, 0.9982, 0.593],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'elephant',\n",
+       "        'score': 0.5921},\n",
+       "       {'box': [0.5931, 0.5993, 0.8453, 0.9989],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'handbag',\n",
+       "        'score': 0.5109},\n",
+       "       {'box': [0.2756, 0.6067, 0.7645, 0.9982],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.4551},\n",
+       "       {'box': [0.2453, 0.6043, 0.7971, 0.9981],\n",
+       "        'box_format': 'xyxy_normalized',\n",
+       "        'label': 'backpack',\n",
+       "        'score': 0.4068}],\n",
+       "      'frame_id': 'frame-scene-16.000-18.947-18.210',\n",
+       "      'timestamp_sec': 18.21}],\n",
+       "    'summary': {'counts': {'backpack': 5,\n",
+       "      'elephant': 10,\n",
+       "      'handbag': 3,\n",
+       "      'person': 3},\n",
+       "     'labels': ['backpack', 'elephant', 'handbag', 'person'],\n",
+       "     'max_scores': {'backpack': 0.5272,\n",
+       "      'elephant': 0.9037,\n",
+       "      'handbag': 0.5109,\n",
+       "      'person': 0.9201}}},\n",
+       "   'end': 18.947,\n",
+       "   'metadata': {},\n",
+       "   'scene_id': 'scene-16.000-18.947',\n",
+       "   'start': 16.0}],\n",
+       " 'status': 'done',\n",
+       " 'type': 'object_detection'}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "detection_understanding = video.understand(\n",
+    "    segmentation={\"type\": \"time\", \"seconds\": 8},\n",
+    "    sampling={\"strategy\": \"uniform\", \"frame_count\": 3},\n",
+    "    analyzers=[\n",
+    "        {\n",
+    "            \"type\": \"object_detection\",\n",
+    "            \"name\": \"objects\",\n",
+    "            \"config\": {\n",
+    "                \"model\": OBJECT_DETECTION_MODEL,\n",
+    "                \"sandbox_id\": sandbox.id,\n",
+    "                \"confidence_threshold\": 0.35,\n",
+    "                \"include_bounding_boxes\": True,\n",
+    "            },\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "detection_understanding.wait_until_complete(timeout=1800, poll_interval=10)\n",
+    "if not detection_understanding.is_successful:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Object detection failed with status {detection_understanding.status}\"\n",
+    "    )\n",
+    "\n",
+    "object_output = detection_understanding.get_analyzer(\"objects\").get_output()\n",
+    "print(\"Understanding ID:\", detection_understanding.id)\n",
+    "object_output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a8b1e91",
+   "metadata": {},
+   "source": [
+    "## 6. Text-to-speech — OmniVoice\n",
+    "\n",
+    "Generation APIs are **asynchronous**: `generate_voice` returns a job; `wait()` returns a normal VideoDB `Audio` asset. Use `config={\"instructions\": ...}` to steer the voice (voice design)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "08cfcd40",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Job ID: 905f66c5-11e1-4333-b8fd-51e70aab825e | Audio ID: a-z-019f979b-c74f-7352-86f3-55d12432c215\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                <audio  controls=\"controls\" >\n",
+       "                    <source src=\"https://storage.googleapis.com/videodb-dev.appspot.com/media/u-010867dd-b86d-4f79-8ba9-911ed8b14dbb/a-z-019f979b-c74f-7352-86f3-55d12432c215/audio?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=firebase-adminsdk-x61ng%40videodb-dev.iam.gserviceaccount.com%2F20260725%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20260725T044959Z&X-Goog-Expires=604799&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B&X-Goog-Signature=0ca32db09ff085cf8422cb6cf0e60036edabde454d9506c05893849e7605e9180344baca0292bf4ab0b370bb63027ca619f98738c4ee0f72f7ea4a4e4f7567f8f93bd53fdfc2b95b51cf7b6dd3003944ecfbb0d79d34ee84ced2da80c64bb9449da0b4c3648dde766ac2c162d85350e4fee55b2c47c3e7dfc78825ff8f1119e93bdea7b8456a1436cb1811005436cab866ef1ab451a87cb2a8fb43c75b76da5c1d0be00fd57d98828df865806d8850482bad797f28b5ec6219b28adaaf3242307003f72132f74928a2cba0b615f9258a8a4f3815351b4170fea67bc24781f27bb4274a788900bef3b1eb9fd810b903b0cef5ab0c25f48743ae384d70259af160\" type=\"None\" />\n",
+       "                    Your browser does not support the audio element.\n",
+       "                </audio>\n",
+       "              "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.Audio object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import Audio as NotebookAudio, display\n",
+    "\n",
+    "voice_job = collection.generate_voice(\n",
+    "    text=\"Welcome to VideoDB Sandbox Compute. This voice was generated on dedicated inference compute.\",\n",
+    "    model_name=TTS_MODEL,\n",
+    "    sandbox_id=sandbox.id,\n",
+    "    config={\"instructions\": \"A clear, friendly product-demo narrator\"},\n",
+    ")\n",
+    "\n",
+    "generated_audio = voice_job.wait(timeout=900, interval=5)\n",
+    "print(\"Job ID:\", voice_job.id, \"| Audio ID:\", generated_audio.id)\n",
+    "display(NotebookAudio(url=generated_audio.generate_url()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "401ac347",
+   "metadata": {},
+   "source": [
+    "## 7. Image generation — FLUX\n",
+    "\n",
+    "Also async. FLUX runs on the `medium` tier; `config` is forwarded to the model (`size`, `num_inference_steps`, `guidance_scale`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "0b3e3457",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Job ID: 48c98104-5b34-4e7e-a291-f63e09859ce0 | Image ID: img-z-019f979c-1011-78d3-8dd6-e7019f6a76c4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<img src=\"https://storage.dev.videodb.io/media/u-010867dd-b86d-4f79-8ba9-911ed8b14dbb/img-z-019f979c-1011-78d3-8dd6-e7019f6a76c4/image?Expires=1785473420&KeyName=videodb-dev-storage-key-1&Signature=BDfImGpjQpyX8t_mjeQSjEiXO-4\"/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import Image as NotebookImage\n",
+    "\n",
+    "image_job = collection.generate_image(\n",
+    "    prompt=(\n",
+    "        \"A compact GPU server in a clean futuristic studio, cinematic lighting, \"\n",
+    "        \"high detail, no text\"\n",
+    "    ),\n",
+    "    model_name=IMAGE_GENERATION_MODEL,\n",
+    "    sandbox_id=sandbox.id,\n",
+    "    config={\n",
+    "        \"size\": \"1280x720\",\n",
+    "        \"num_inference_steps\": 28,\n",
+    "        \"guidance_scale\": 4.0,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "generated_image = image_job.wait(timeout=900, interval=5)\n",
+    "print(\"Job ID:\", image_job.id, \"| Image ID:\", generated_image.id)\n",
+    "display(NotebookImage(url=generated_image.generate_url()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8a4fccf",
+   "metadata": {},
+   "source": [
+    "## Model coverage\n",
+    "\n",
+    "| Use case | Model | Min tier | This notebook | Deep-dive |\n",
+    "|---|---|---:|---|---|\n",
+    "| Text | `Qwen/Qwen3.5-9B` | small | ✅ §3 | — |\n",
+    "| Visual understanding | `Qwen/Qwen3.5-9B` | small | ✅ §4 | — |\n",
+    "| Object detection | `rtdetr-v2-r50vd` | small | ✅ §5 | — |\n",
+    "| Text-to-speech | `k2-fsa/OmniVoice` | small | ✅ §6 | `omnivoice_quickstart.ipynb` |\n",
+    "| Image generation | `black-forest-labs/FLUX.1-dev` | medium | ✅ §7 | `flux_quickstart.ipynb` |\n",
+    "| Speech-to-text | `openai/whisper-large-v3-turbo` | small | — | `whisper_quickstart.ipynb` (WAV input) |\n",
+    "| Audio generation | `stabilityai/stable-audio-open-1.0` | small | — | Not yet available via the SDK |\n",
+    "\n",
+    "Single-model deep-dive notebooks live alongside this one in `guides/sandbox/`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e183b994",
+   "metadata": {},
+   "source": [
+    "## 🚨 Cleanup — stop the sandbox\n",
+    "\n",
+    "Billing is runtime-based, so stop the sandbox when you're done. `grace=True` lets accepted work finish before compute is released."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "2d01981a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sandbox ID: bx-13832c0a9e4f4fa9\n",
+      "Final status: stopped\n"
+     ]
+    }
+   ],
+   "source": [
+    "sandbox = conn.get_sandbox(sandbox.id)\n",
+    "\n",
+    "if sandbox.status not in (\"stopped\", \"failed\"):\n",
+    "    sandbox.stop(grace=True)\n",
+    "    sandbox.wait_for_stop(timeout=300, interval=5)\n",
+    "\n",
+    "print(\"Sandbox ID:\", sandbox.id)\n",
+    "print(\"Final status:\", sandbox.status)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/guides/sandbox/quickstart.ipynb
+++ b/guides/sandbox/quickstart.ipynb
@@ -5,6 +5,8 @@
    "id": "85b4a36c",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/video-db/videodb-cookbook/blob/main/guides/sandbox/quickstart.ipynb)\n",
+    "\n",
     "# Sandbox Compute — Quickstart\n",
     "\n",
     "**Sandbox Compute** lets you run supported open-weight models (Gemma, Qwen, Whisper, OmniVoice, FLUX, RT-DETR, …) on dedicated, warm GPU compute inside your VideoDB workflows. You create a *sandbox*, wait until it's active, then pass its `sandbox_id` to any supported API — VideoDB routes that job to your sandbox instead of the default hosted path.\n",
@@ -13,7 +15,7 @@
     "\n",
     "| Step | What it shows |\n",
     "|---|---|\n",
-    "| **Setup** | Install the SDK, connect to dev |\n",
+    "| **Setup** | Install the SDK, connect |\n",
     "| **1. Lifecycle** | Create, wait, retrieve, list a sandbox |\n",
     "| **2. Media** | Upload one sample video reused by the understanding steps |\n",
     "| **3. Text** | `generate_text` — Qwen |\n",
@@ -39,7 +41,7 @@
     "## Setup\n",
     "\n",
     "### Install the SDK\n",
-    "Install the VideoDB SDK (**`videodb==0.5.2`**), which includes the Sandbox interface."
+    "Install the VideoDB SDK (**`videodb==0.5.1`**), which includes the Sandbox interface."
    ]
   },
   {
@@ -59,7 +61,7 @@
     }
    ],
    "source": [
-    "!pip install -q videodb==0.5.2 python-dotenv"
+    "!pip install -q videodb==0.5.1 python-dotenv"
    ]
   },
   {


### PR DESCRIPTION
Adds `guides/sandbox/quickstart.ipynb` — an end-to-end guide to VideoDB **Sandbox Compute**.

## What it covers
Create a sandbox, then run each supported workload through it via the `videodb==0.5.2` SDK:
- **Lifecycle** — create / wait / retrieve / list
- **Text** — `generate_text` (Qwen)
- **Visual understanding** — `video.understand` VLM (Qwen)
- **Object detection** — `video.understand` (RT-DETR)
- **Text-to-speech** — `generate_voice` (OmniVoice)
- **Image generation** — `generate_image` (FLUX)
- **Cleanup** — stop the sandbox

Includes an overview, key-concepts section, a model-coverage table, and executed outputs.

## Notes
- Installs the released `videodb==0.5.2` from PyPI; connects to the default (prod) endpoint.
- Uses a `medium` sandbox (FLUX requires it).
- Executed outputs are included; no credentials are embedded.